### PR TITLE
print a human-readable message on SSL handshake error

### DIFF
--- a/mssl.c
+++ b/mssl.c
@@ -253,7 +253,7 @@ int connect_ssl(const int fd, SSL_CTX *const client_ctx, SSL **const ssl_h, BIO 
 			}
 			else
 			{
-				set_error(gettext("SSL handshake error: %s"), SSL_get_error(*ssl_h, err));
+				set_error(gettext("SSL handshake error: %s"), ERR_reason_error_string(ERR_get_error()));
 				return -1;
 			}
 		}


### PR DESCRIPTION
without this patch, doing
`httping -l -g https://dh480.badssl.com/`
it will result in:
`SSL handshake error: (null)`
with the patch instead it prints:
`SSL handshake error: dh key too small`