### PR TITLE
nc.c: add <unistd.h> for useconds_t

### DIFF
--- a/nc.c
+++ b/nc.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 #include <ncurses.h>
 


### PR DESCRIPTION
Without the change bud fails on darwin as:

    clang -Wall -W -Wextra -pedantic -D_FORTIFY_SOURCE=2  -DVERSION=\"2.9\" -DLOCALEDIR=\"/usr/share/locale\" -DNC -DFW -D_DEBUG -ggdb   -c -o nc.o nc.c
    In file included from nc.c:22:
    ./utils.h:19:15: error: unknown type name 'useconds_t'
    void myusleep(useconds_t v);
                  ^
    make: *** [<builtin>: nc.o] Error 1

Closes: https://github.com/folkertvanheusden/HTTPing/issues/4