### PR TITLE
http.c: add <stdlib.h> for malloc

### DIFF
--- a/http.c
+++ b/http.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #ifndef NO_SSL


### PR DESCRIPTION
GCC 14 makes implicit function declarations an error by default:
```
http.c: In function ‘get_HTTP_headers’:
http.c:21:32: error: implicit declaration of function ‘malloc’ [-Wimplicit-function-declaration]
   21 |         char *buffer = (char *)malloc(len + 1);
      |                                ^~~~~~
http.c:16:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’
   15 | #include "utils.h"
  +++ |+#include <stdlib.h>
   16 |
[...]
```

Bug: https://bugs.gentoo.org/920107