### PR TITLE
README.md: fix linting and simplify cmake commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 httping
 =======
 
-Ping with HTTP requests, see http://www.vanheusden.com/httping/
-
+Ping with HTTP requests, see <http://www.vanheusden.com/httping/>.
 
 Compiling:
 
-* mkdir build
-* cd build
-* cmake ..
-* make
+* cmake -B build
+* cmake --build build
 
 If you would like the TUI (text user interface) to be included (for -K),
 use:
-* cmake -DUSE_TUI=1 ..
 
-If you want httping to use local translations, add "-DUSE_GETTEXT=1" to
+* cmake -DUSE_TUI=ON build
+
+If you want httping to use local translations, add "-DUSE_GETTEXT=ON" to
 the cmake commandline.
-
 
 The AGPL v3.0 license applies to this software.


### PR DESCRIPTION
Use the modern CMake commandline options to set up and compile the project.

Also use "ON" and "OFF" keywords instead of "0" and "1" for the boolean options.