### PR TITLE
mssl.c: remove deprecated routines

### DIFF
--- a/mssl.c
+++ b/mssl.c
@@ -36,8 +36,6 @@ void shutdown_ssl(void)
 
 	ERR_free_strings();
 
-	ERR_remove_state(0);
-	ENGINE_cleanup();
 	CONF_modules_free();
 	EVP_cleanup();
 	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Both ERR_remove_state and ENGINE_cleanup were deprecated since OpenSSL 1.0.0 and 1.1.0.

For more information see:

* https://docs.openssl.org/3.3/man3/ERR_remove_state/
* https://manpages.debian.org/experimental/libssl-doc/ENGINE_cleanup.3ssl.en.html

Fixes #28 