### PR TITLE
CMakeLists.txt: convert custom settings to options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(httping LANGUAGES C VERSION "4.2.0")
 # Create compile_commands.json file
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
+option(USE_TUI "Enable text user interface" OFF)
+option(USE_FFTW3 "Enable FFTW3 backend (depedns on USE_TUI)" OFF)
+option(USE_SSL "Enable SSL support" OFF)
+option(USE_GETTEXT "Enable interantionalization" OFF)
+
 add_definitions(-DLOCALEDIR=\"/usr/local/share/locale\")
 
 set(SOURCES  colors.c cookies.c error.c fft.c gen.c help.c http.c io.c kalman.c main.c mssl.c nc.c res.c socks5.c tcp.c utils.c)
@@ -14,11 +19,11 @@ add_executable(httping ${SOURCES})
 
 target_link_libraries(httping m)
 
-find_package(Intl REQUIRED)
-target_link_libraries(httping Intl::Intl)
-
 if(USE_GETTEXT)
   find_package(Gettext REQUIRED)
+
+  find_package(Intl REQUIRED)
+  target_link_libraries(httping Intl::Intl)
 endif()
 
 set(CMAKE_BUILD_TYPE Debug)
@@ -26,19 +31,23 @@ set(CMAKE_BUILD_TYPE Debug)
 include(FindPkgConfig)
 
 if(USE_TUI)
-  pkg_check_modules(NCURSES ncurses)
+  pkg_check_modules(NCURSES REQUIRED ncurses)
   target_link_libraries(httping ${NCURSES_LIBRARIES})
   target_include_directories(httping PUBLIC ${NCURSES_INCLUDE_DIRS})
   target_compile_options(httping PUBLIC ${NCURSES_CFLAGS_OTHER})
 
-  pkg_check_modules(FFTW3 fftw3)
-  target_link_libraries(httping ${FFTW3_LIBRARIES})
-  target_include_directories(httping PUBLIC ${FFTW3_INCLUDE_DIRS})
-  target_compile_options(httping PUBLIC ${FFTW3_CFLAGS_OTHER})
+  if(USE_FFTW3)
+    pkg_check_modules(FFTW3 REQUIRED fftw3)
+    target_link_libraries(httping ${FFTW3_LIBRARIES})
+    target_include_directories(httping PUBLIC ${FFTW3_INCLUDE_DIRS})
+    target_compile_options(httping PUBLIC ${FFTW3_CFLAGS_OTHER})
+  endif()
 endif()
 
-find_package(OpenSSL REQUIRED)
-target_link_libraries(httping OpenSSL::SSL OpenSSL::Crypto)
+if(USE_SSL)
+  find_package(OpenSSL REQUIRED)
+  target_link_libraries(httping OpenSSL::SSL OpenSSL::Crypto)
+endif()
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,24 @@ Ping with HTTP requests, see <http://www.vanheusden.com/httping/>.
 
 Compiling:
 
-* cmake -B build
-* cmake --build build
+* `cmake -B build`
+* `cmake --build build`
+
+This configuration will build a binary with the minimal functionality.
+You can use the following options to add more features to httping:
+
+If you need the SSL support, use (requires `OpenSSL` library):
+
+* `cmake -DUSE_SSL=ON build`
 
 If you would like the TUI (text user interface) to be included (for -K),
-use:
+use (requires `ncurses` library):
 
-* cmake -DUSE_TUI=ON build
+* `cmake -DUSE_TUI=ON build`
 
-If you want httping to use local translations, add "-DUSE_GETTEXT=ON" to
+Adding `-DUSE_FFTW3=ON` to the `-DUSE_TUI=ON` allows TUI to show performance graphics. This option requires `fftw3` library.
+
+If you want httping to use local translations, add `-DUSE_GETTEXT=ON` to
 the cmake commandline.
 
 The AGPL v3.0 license applies to this software.


### PR DESCRIPTION
Introduce the following options:

* `USE_TUI` - Enable text user interface
* `USE_FFTW3` - Enable FFTW3 backend (depedns on USE_TUI)
* `USE_SSL` - Enable SSL support
* `USE_GETTEXT` - Enable interantionalization

Set all options to `OFF` by default.