### PR TITLE
Simplify internationalisation handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,6 @@ option(USE_FFTW3 "Enable FFTW3 backend (depedns on USE_TUI)" OFF)
 option(USE_SSL "Enable SSL support" OFF)
 option(USE_GETTEXT "Enable interantionalization" OFF)
 
-add_definitions(-DLOCALEDIR=\"/usr/local/share/locale\")
-
 set(SOURCES  colors.c cookies.c error.c fft.c gen.c help.c http.c io.c kalman.c main.c mssl.c nc.c res.c socks5.c tcp.c utils.c)
 add_executable(httping ${SOURCES})
 

--- a/config.h.in
+++ b/config.h.in
@@ -4,6 +4,8 @@
 
 #define VERSION "@PROJECT_VERSION@"
 
+#define LOCALEDIR "@CMAKE_INSTALL_FULL_LOCALEDIR@"
+
 #cmakedefine01 FFTW3_FOUND
 #define HAVE_FFTW3 FFTW3_FOUND
 
@@ -12,6 +14,9 @@
 
 #cmakedefine01 OPENSSL_FOUND
 #define HAVE_OPENSSL OPENSSL_FOUND
+
+#cmakedefine01 INTL_FOUND
+#define HAVE_INTL INTL_FOUND
 
 #if !HAVE_OPENSSL
 #define NO_SSL

--- a/gen.h
+++ b/gen.h
@@ -28,7 +28,7 @@
 #define min(x, y) ((x) < (y) ? (x) : (y))
 #define max(x, y) ((x) > (y) ? (x) : (y))
 
-#if USE_GETTEXT
+#if INTL_FOUND
 #include <libintl.h>
 #else
 #define gettext(x) (x)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,37 +1,22 @@
-add_definitions(-DUSE_GETTEXT=1)
+set(catalogname httping)
 
-find_program(GETTEXT_MSGFMT_EXECUTABLE msgfmt)
+file(GLOB PO_FILES *.po)
 
-if(NOT GETTEXT_MSGFMT_EXECUTABLE)
-  message("------ NOTE: msgfmt not found. Translations will *not* be installed ------")
-else(NOT GETTEXT_MSGFMT_EXECUTABLE)
+foreach(_poFile ${PO_FILES})
+  get_filename_component(_poFileName ${_poFile} NAME)
+  string(REGEX REPLACE "^${catalogname}_?" "" _langCode ${_poFileName})
+  string(REGEX REPLACE "\\.po$" "" _langCode ${_langCode})
 
-  set(catalogname httping)
+  if( _langCode )
+    get_filename_component(_lang ${_poFile} NAME_WE)
+    set(_gmoFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.gmo)
 
-  file(GLOB PO_FILES *.po)
-  set(GMO_FILES)
+    gettext_process_po_files(${_langCode} ALL PO_FILES ${_poFile})
+    install(
+      FILES ${_gmoFile}
+      DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${_langCode}/LC_MESSAGES/
+      RENAME ${catalogname}.mo
+    )
+  endif()
 
-  foreach(_poFile ${PO_FILES})
-    get_filename_component(_poFileName ${_poFile} NAME)
-    string(REGEX REPLACE "^${catalogname}_?" "" _langCode ${_poFileName} )
-    string(REGEX REPLACE "\\.po$" "" _langCode ${_langCode} )
-
-    if( _langCode )
-      get_filename_component(_lang ${_poFile} NAME_WE)
-      set(_gmoFile ${CMAKE_CURRENT_BINARY_DIR}/${_lang}.gmo)
-
-      add_custom_command(OUTPUT ${_gmoFile}
-        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --check -o ${_gmoFile} ${_poFile}
-        DEPENDS ${_poFile})
-      install(FILES ${_gmoFile} DESTINATION ${CMAKE_INSTALL_LOCALEDIR}/${_langCode}/LC_MESSAGES/ RENAME ${catalogname}.mo)
-      list(APPEND GMO_FILES ${_gmoFile})
-    endif( _langCode )
-
-  endforeach(_poFile ${PO_FILES})
-
-  add_custom_target(translations ALL DEPENDS ${GMO_FILES})
-
-endif(NOT GETTEXT_MSGFMT_EXECUTABLE)
-
-#install(FILES ${CMAKE_CURRENT_BINARY_DIR}/nl.mo DESTINATION ${CMAKE_INSTALL_LOCALEDIR})
-#install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ru.mo DESTINATION ${CMAKE_INSTALL_LOCALEDIR})
+endforeach()


### PR DESCRIPTION
Use `config.h.in` for all definitions:

- introduce `INTL_FOUND` macro
- use `CMAKE_INSTALL_FULL_LOCALEDIR` variable for `LOCALEDIR`

Don't check for `msgfmt` as it is already done in the `find_package()` call. Also use `gettext_process_po_files()` macro to convert `po` files to `gmo` files.