### PR TITLE
chore: update gitignore to ignore `*.mo` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 tags
 compile_commands.json
+
+# Translations
+*.mo


### PR DESCRIPTION
split from #18 