### PR TITLE
main.c: fix redefined warning

### DIFF
--- a/main.c
+++ b/main.c
@@ -5,7 +5,9 @@
 #include <libintl.h>
 #endif
 #define _GNU_SOURCE
+#ifndef __USE_XOPEN
 #define __USE_XOPEN
+#endif
 #include <time.h>
 #include <sys/ioctl.h>
 #include <stdio.h>


### PR DESCRIPTION
Usually, the `__USE_XOPEN` macro is defined via `_GNU_SOURCE`. But some toolchains handle this differently. Hence define `__USE_XOPEN` only if it has not been already defined.