### PR TITLE
Resolve empty translation unit warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,32 @@ option(USE_FFTW3 "Enable FFTW3 backend (depedns on USE_TUI)" OFF)
 option(USE_SSL "Enable SSL support" OFF)
 option(USE_GETTEXT "Enable interantionalization" OFF)
 
-set(SOURCES  colors.c cookies.c error.c fft.c gen.c help.c http.c io.c kalman.c main.c mssl.c nc.c res.c socks5.c tcp.c utils.c)
+set(SOURCES
+  colors.c
+  cookies.c
+  error.c
+  gen.c
+  help.c
+  http.c
+  io.c
+  kalman.c
+  main.c
+  res.c
+  socks5.c
+  tcp.c
+  utils.c
+)
+
+if(USE_SSL)
+  set(SOURCES ${SOURCES} mssl.c)
+endif()
+if(USE_FFTW3)
+  set(SOURCES ${SOURCES} fft.c)
+endif()
+if(USE_TUI)
+  set(SOURCES ${SOURCES} nc.c)
+endif()
+
 add_executable(httping ${SOURCES})
 
 target_link_libraries(httping m)

--- a/fft.c
+++ b/fft.c
@@ -1,5 +1,4 @@
 #include "config.h"
-#if HAVE_FFTW3
 #include "gen.h"
 #include <math.h>
 #include <stdlib.h>
@@ -68,4 +67,3 @@ void fft_do(double *in, double *output_mag, double *output_phase)
 		output_phase[loop] = (real == 0 && img == 0) ? 0 : atan2(real, img);
 	}
 }
-#endif

--- a/mssl.c
+++ b/mssl.c
@@ -1,6 +1,5 @@
 /* Released under AGPL v3 with exception for the OpenSSL library. See license.txt */
 #include "config.h"
-#ifndef NO_SSL
 #include <errno.h>
 #include "gen.h"
 #include <string.h>
@@ -421,4 +420,3 @@ int connect_ssl_proxy(const int fd, struct addrinfo *const ai, const double time
 
 	return RC_OK;
 }
-#endif

--- a/nc.c
+++ b/nc.c
@@ -1,5 +1,4 @@
 #include "config.h"
-#if HAVE_NCURSES
 #define _GNU_SOURCE
 #include <stdio.h>
 #include "gen.h"
@@ -867,4 +866,3 @@ void update_stats(stats_t *resolve, stats_t *connect, stats_t *request, stats_t 
 	if (win_resize || force_redraw)
 		recreate_terminal();
 }
-#endif


### PR DESCRIPTION
When some options like `USE_TUI` or `USE_SSL` are disabled, we get empty translation units, because the whole code was disabled via `HAVE_<OPTION>` defines. The related warning was:

ISO C forbids an empty translation unit

Compile these units only when the related option is enabled