### PR TITLE
CMakeLists.txt: fix fft.c compilation

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,12 @@ jobs:
         cmake -B build -DUSE_TUI=ON -DUSE_FFTW3=ON -DUSE_SSL=OFF -DUSE_GETTEXT=OFF
         cmake --build build
 
+    - name: Configure and build with clang (FFTW3 without TUI support)
+      run: |
+        rm -fr build
+        cmake -B build -DUSE_TUI=OFF -DUSE_FFTW3=ON -DUSE_SSL=OFF -DUSE_GETTEXT=OFF
+        cmake --build build
+
     - name: Configure and build with clang (full TUI support, SSL, and gettext)
       run: |
         rm -fr build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,12 @@ set(SOURCES
 if(USE_SSL)
   set(SOURCES ${SOURCES} mssl.c)
 endif()
-if(USE_FFTW3)
-  set(SOURCES ${SOURCES} fft.c)
-endif()
+
 if(USE_TUI)
   set(SOURCES ${SOURCES} nc.c)
+  if(USE_FFTW3)
+    set(SOURCES ${SOURCES} fft.c)
+  endif()
 endif()
 
 add_executable(httping ${SOURCES})


### PR DESCRIPTION
Build `fft.c` only if both `USE_TUI` and `USE_FFTW3` are enabled.