### PR TITLE
Install in to the appropriate man page section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ target_include_directories(httping PUBLIC "${PROJECT_BINARY_DIR}")
 
 install(TARGETS httping DESTINATION bin)
 install(FILES README.md LICENSE plot-json.py DESTINATION ${CMAKE_INSTALL_DOCDIR})
-install(FILES httping.1 DESTINATION ${CMAKE_INSTALL_MANDIR})
+install(FILES httping.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 # setup summary
 message(STATUS "CMake version: ${CMAKE_VERSION}")


### PR DESCRIPTION
Noticed an install issue, the man page is not installed in to a man page section which results in it not being easily accessible with `man(1)` unless the builder overrides the path.