### PR TITLE
Remove openssl/engine.h inclusion

### DIFF
--- a/mssl.c
+++ b/mssl.c
@@ -11,7 +11,6 @@
 #include <sys/socket.h>
 #include <openssl/bio.h>
 #include <openssl/conf.h>
-#include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/md5.h>


### PR DESCRIPTION
The last reference to ENGINE was removed in 
commit 835efac181f0ed3998c2302042d35c231c3b9260.