### PR TITLE
CI: remove cross-compilation toolchains

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -34,9 +34,6 @@ jobs:
                 cmake \
                 pkg-config \
                 gcc \
-                gcc-aarch64-linux-gnu \
-                gcc-arm-linux-gnueabihf \
-                gcc-mips-linux-gnu \
                 libncurses-dev \
                 fftw-dev \
                 libfftw3-dev \


### PR DESCRIPTION
So far, we perform build tests only for x64. Hence, remove the other toolchains.